### PR TITLE
feat: add auto-update script

### DIFF
--- a/auto-update.ps1
+++ b/auto-update.ps1
@@ -1,0 +1,39 @@
+# Check if zed.exe is running
+$zedProcess = Get-Process -Name "zed" -ErrorAction SilentlyContinue
+if ($zedProcess) {
+    Write-Host "Zed is running now"
+    exit 1
+}
+
+# Define the path to the Zed installation directory
+$zedPath = "D:\software\bin"
+
+# Get the version of the current Zed executable
+$zedVersionUrl = "https://raw.githubusercontent.com/sonercirit/zed-windows-stable/refs/heads/main/latest_build.txt"
+$zedVersion = Invoke-RestMethod -Uri $zedVersionUrl -ErrorAction Stop
+
+# Define the URL for the latest Zed release
+$zedUrl = "https://github.com/sonercirit/zed-windows-stable/releases/latest/download/zed-windows-" + $zedVersion + ".exe"
+
+# Download the latest Zed executable
+$zedExePath = Join-Path -Path $zedPath -ChildPath "zed_new.exe"
+Invoke-WebRequest -Uri $zedUrl -OutFile $zedExePath
+# Check if the download was successful
+if (-Not (Test-Path -Path $zedExePath)) {
+    Write-Host "Failed to download Zed executable."
+    exit 1
+} else {
+    Write-Host "Zed executable downloaded successfully."
+    # Delete old zed
+    $oldZedPath = Join-Path -Path $zedPath -ChildPath "zed.exe"
+    if (Test-Path -Path $oldZedPath) {
+        Remove-Item -Path $oldZedPath -Force
+        Write-Host "Old Zed executable removed."
+    } else {
+        Write-Host "No old Zed executable found to remove."
+    }
+    # Rename the new zed executable
+    Rename-Item -Path $zedExePath -NewName "zed.exe" -Force
+    Write-Host "New Zed executable renamed successfully."
+    exit 0
+}


### PR DESCRIPTION
This pull request introduces an `auto-update.ps1` script to automate the update process for the Zed application on Windows. The script checks if Zed is running, fetches the latest version, downloads the new executable, and replaces the old version if it exists.

### New auto-update script for Zed:

* Added a check to ensure the Zed application is not running before proceeding with the update. If Zed is running, the script exits with a message. (`auto-update.ps1`, [auto-update.ps1R1-R39](diffhunk://#diff-dd459564078f8603f76e4e260e1b828c7fb2c90aea2a05981fa035d8694935d3R1-R39))
* Fetches the latest version number from a remote URL (`latest_build.txt`) and constructs the download URL for the corresponding release. (`auto-update.ps1`, [auto-update.ps1R1-R39](diffhunk://#diff-dd459564078f8603f76e4e260e1b828c7fb2c90aea2a05981fa035d8694935d3R1-R39))
* Downloads the new executable to a temporary file, verifies the download, and removes the old executable if it exists. (`auto-update.ps1`, [auto-update.ps1R1-R39](diffhunk://#diff-dd459564078f8603f76e4e260e1b828c7fb2c90aea2a05981fa035d8694935d3R1-R39))
* Renames the downloaded file to replace the old executable, completing the update process. (`auto-update.ps1`, [auto-update.ps1R1-R39](diffhunk://#diff-dd459564078f8603f76e4e260e1b828c7fb2c90aea2a05981fa035d8694935d3R1-R39))